### PR TITLE
Serial panel adjust

### DIFF
--- a/source/comunicacaoserial.cpp
+++ b/source/comunicacaoserial.cpp
@@ -1,3 +1,57 @@
 #include "comunicacaoserial.h"
 
+comunicacaoSerial::comunicacaoSerial(QSerialPort *serialDevice)
+{
+    myDevice = serialDevice;
+}
 
+QStringList comunicacaoSerial::loadDevices()
+{
+    QStringList devs;
+
+    foreach (const QSerialPortInfo info, QSerialPortInfo::availablePorts()) {
+
+        myDevice->setPort(info);
+
+
+        if (myDevice->open(QIODevice::ReadWrite)) {
+            myDevice->close();
+            devs << info.portName();
+        }
+
+    }
+    return devs;
+}
+
+bool comunicacaoSerial::createConnection(QString device, uint32_t baudRate)
+{
+    myDevice->setPortName(device);
+    switch (baudRate)
+    {
+        case 9600:
+             myDevice->setBaudRate(QSerialPort::Baud9600);
+            break;
+        case 19200:
+             myDevice->setBaudRate(QSerialPort::Baud19200);
+            break;
+        case 57600:
+             myDevice->setBaudRate(QSerialPort::Baud57600);
+            break;
+        case 115200:
+             myDevice->setBaudRate(QSerialPort::Baud115200);
+            break;
+    }
+    myDevice->setBaudRate(QSerialPort::Baud9600);
+    myDevice->setDataBits(QSerialPort::Data8);
+    myDevice->setParity(QSerialPort::NoParity);
+    myDevice->setStopBits(QSerialPort::OneStop);
+    myDevice->setFlowControl(QSerialPort::NoFlowControl);
+    myDevice->open(QIODevice::ReadWrite);
+    return true;
+}
+
+void comunicacaoSerial::closeConnection()
+{
+    myDevice->clear();
+    myDevice->close();
+}

--- a/source/comunicacaoserial.h
+++ b/source/comunicacaoserial.h
@@ -2,12 +2,21 @@
 #define COMUNICACAOSERIAL_H
 
 #include <QSerialPort>
+#include <QtSerialPort/QSerialPort>
+#include <QtSerialPort/QSerialPortInfo>
 #include <QDebug>
 
 class comunicacaoSerial
 {
 public:
-   // QSerialPort *serial;
+   comunicacaoSerial();
+   comunicacaoSerial(QSerialPort *serialDevice);
+    // QSerialPort *serial;
+    QStringList loadDevices();
+    bool createConnection(QString device, uint32_t baudRate);
+    void closeConnection();
+protected:
+    QSerialPort *myDevice;
 };
 
 #endif // COMUNICACAOSERIAL_H

--- a/source/comunicacaoserial.h
+++ b/source/comunicacaoserial.h
@@ -14,7 +14,7 @@ public:
     // QSerialPort *serial;
     QStringList loadDevices();
     bool createConnection(QString device, uint32_t baudRate);
-    void closeConnection();
+    bool closeConnection();
 protected:
     QSerialPort *myDevice;
 };

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -88,11 +88,36 @@ void MainWindow::serialReceived(){
     //ui->tx_receivedData;
     addPoint(ui->label->text().toDouble());
     plot();
-    qDebug()<< "no data received";
+    //qDebug()<< "no data received";
 }
 
-void MainWindow::on_pushButton_clicked()
+void MainWindow::on_pb_connect_clicked()
 {
-    comunicacaoSerial_->createConnection(ui->cb_serialDevices->currentText(),ui->cb_baudRate->currentText().toInt());
+    if(comunicacaoSerial_->createConnection(ui->cb_serialDevices->currentText(),ui->cb_baudRate->currentText().toInt()))
+    {
+        ui->cb_serialDevices->setEnabled(false);
+        ui->cb_baudRate->setEnabled(false);
+        ui->pb_connect->setEnabled(false);
+        ui->pb_disconnect->setEnabled(true);
+    }
+    else
+    {
+        qDebug() << "Connection not possible.";
+    }
     //serial->setPortName(ui->cb_serialDevices->currentText());
+}
+
+void MainWindow::on_pb_disconnect_clicked()
+{
+     if (comunicacaoSerial_->closeConnection())
+     {
+         ui->cb_serialDevices->setEnabled(true);
+         ui->cb_baudRate->setEnabled(true);
+         ui->pb_connect->setEnabled(true);
+         ui->pb_disconnect->setEnabled(false);
+     }
+     else
+     {
+         qDebug() << "Connection not possible.";
+     }
 }

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -3,30 +3,77 @@
 #include <QSerialPort>
 #include <QDebug>
 
-
-QSerialPort *serial;
-QCustomPlot *graphic;
-//comunicacaoSerial *comunicacaoSerial_ = comunicacaoSerial_->getInstance();
-
+/* **********************************************************************
+ *              Constructor & Destructor
+ * **********************************************************************/
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
 {
+    //Initialize objects
     ui->setupUi(this);
-/********************************************
-*              Graphic stuff
-******************************************/
-  //  graphic = new QCustomPlot(this);
 
-    //graphic->addGraph();
-    //graphic->graph(0)->setPen(QPen(Qt::blue));
+    serial = new QSerialPort(this);
+    comunicacaoSerial_ = new comunicacaoSerial(serial);
+
+    //Setup Graphic environment
+    setGraphicEnvironment();
+
+    //Fill comboBoxes options
+    ui->cb_serialDevices->addItems(comunicacaoSerial_->loadDevices());
+
+    //Set signal(s)
+    connect(serial,SIGNAL(readyRead()), this, SLOT(serialReceived()));
+
+
+}
+
+MainWindow::~MainWindow()
+{
+    delete ui;
+    serial->close();
+}
+
+/* **********************************************************************
+ *              QtCustom plot configuration (graphic)
+ * **********************************************************************/
+
+//Configure grapgic style and parameters
+void MainWindow::setGraphicEnvironment()
+{
     ui->plot->addGraph();
     ui->plot->graph(0)->setPen(QPen(Qt::green));
     ui->plot->xAxis->setRange(0,1000);
     ui->plot->yAxis->setRange(-1,1);
 
+    ui->plot->yAxis->setLabelColor(Qt::white);
+    ui->plot->xAxis->setLabelColor(Qt::white);
+
+    ui->plot->xAxis->setLabel("Time");
+    ui->plot->yAxis->setLabel("Amplitude [v]");
+
+    ui->plot->xAxis->setBasePen(QPen(Qt::white, 1));
+    ui->plot->yAxis->setBasePen(QPen(Qt::white, 1));
+    ui->plot->xAxis->setTickPen(QPen(Qt::white, 1));
+    ui->plot->yAxis->setTickPen(QPen(Qt::white, 1));
+    ui->plot->xAxis->setSubTickPen(QPen(Qt::white, 1));
+    ui->plot->yAxis->setSubTickPen(QPen(Qt::white, 1));
+//    ui->plot->xAxis->setTickLabelColor(Qt::white);
+    ui->plot->xAxis->setTickLabels(false);
+    ui->plot->yAxis->setTickLabelColor(Qt::white);
+
     ui->plot->xAxis->grid()->setPen(QPen(QColor(140, 140, 140), 1, Qt::DotLine));
     ui->plot->yAxis->grid()->setPen(QPen(QColor(140, 140, 140), 1, Qt::DotLine));
+
+    ui->plot->xAxis->grid()->setSubGridPen(QPen(QColor(80, 80, 80), 1, Qt::DotLine));
+    ui->plot->yAxis->grid()->setSubGridPen(QPen(QColor(80, 80, 80), 1, Qt::DotLine));
+    ui->plot->xAxis->grid()->setSubGridVisible(true);
+    ui->plot->yAxis->grid()->setSubGridVisible(true);
+    ui->plot->xAxis->grid()->setZeroLinePen(Qt::NoPen);
+    ui->plot->yAxis->grid()->setZeroLinePen(Qt::NoPen);
+
+    //ui->plot->yAxis->setUpperEnding(QCPLineEnding::esSpikeArrow);
+    ui->plot->xAxis->setUpperEnding(QCPLineEnding::esSpikeArrow);
 
     QLinearGradient plotGradient;
     plotGradient.setStart(0,-1);
@@ -42,30 +89,13 @@ MainWindow::MainWindow(QWidget *parent)
     axisRectGradient.setColorAt(1, QColor(30, 30, 30));
     ui->plot->axisRect()->setBackground(axisRectGradient);
 
-/********************************************
- *      Serial stuff
- ******************************************/
-    serial = new QSerialPort(this);
-    comunicacaoSerial_ = new comunicacaoSerial(serial);
-    ui->cb_serialDevices->addItems(comunicacaoSerial_->loadDevices());
-    connect(serial,SIGNAL(readyRead()), this, SLOT(serialReceived()));
-
-
 }
 
-MainWindow::~MainWindow()
-{
-    delete ui;
-    serial->close();
-}
+/* **********************************************************************
+ *              Data display
+ * **********************************************************************/
 
-void MainWindow::addPoint(double y)
-{
-    qv_y.append(y);
-    qv_x.append(qv_x.last()+3);
-    ui->tx_receivedData->append(QString::number(y));
-}
-
+//Plot and display data in the graphic
 void MainWindow::plot()
 {
     ui->plot->graph(0)->setData(qv_x,qv_y);
@@ -78,19 +108,33 @@ void MainWindow::plot()
         qv_x.clear();
         qv_x.push_back(0);
      }
-        //ui->plot->graph(0)->rescaleAxes();
     ui->plot->replot();
     ui->plot->update();
 }
 
+/* **********************************************************************
+ *              Serial communication
+ * **********************************************************************/
+
+//Handles serial reception signal
 void MainWindow::serialReceived(){
     ui->label->setText(serial->readLine());
-    //ui->tx_receivedData;
     addPoint(ui->label->text().toDouble());
     plot();
-    //qDebug()<< "no data received";
 }
 
+//Save data from serial port
+void MainWindow::addPoint(double y)
+{
+    qv_y.append(y);
+    qv_x.append(qv_x.last()+3);
+    ui->tx_receivedData->append(QString::number(y));
+}
+
+
+/* **********************************************************************
+ *              Control Elements Actions (Buttons & etc
+ * **********************************************************************/
 void MainWindow::on_pb_connect_clicked()
 {
     if(comunicacaoSerial_->createConnection(ui->cb_serialDevices->currentText(),ui->cb_baudRate->currentText().toInt()))
@@ -104,7 +148,6 @@ void MainWindow::on_pb_connect_clicked()
     {
         qDebug() << "Connection not possible.";
     }
-    //serial->setPortName(ui->cb_serialDevices->currentText());
 }
 
 void MainWindow::on_pb_disconnect_clicked()

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -2,6 +2,7 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QDebug>
 #include <QSerialPort>
 #include "comunicacaoserial.h"
 
@@ -21,9 +22,12 @@ public:
     void plot();
 
 private slots:
+    //Custom signals
     void serialReceived();
 
-    void on_pushButton_clicked();
+    // Graphical elements
+    void on_pb_connect_clicked();
+    void on_pb_disconnect_clicked();
 
 private:
     Ui::MainWindow *ui;

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -23,8 +23,11 @@ public:
 private slots:
     void serialReceived();
 
+    void on_pushButton_clicked();
+
 private:
     Ui::MainWindow *ui;
+    comunicacaoSerial *comunicacaoSerial_;
     QVector<double> qv_x{0}, qv_y{0};
  //   comunicacaoSerial *comunicacaoSerial;
 };

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include <QDebug>
 #include <QSerialPort>
+
 #include "comunicacaoserial.h"
 
 QT_BEGIN_NAMESPACE
@@ -18,6 +19,7 @@ public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
+    void setGraphicEnvironment();
     void addPoint(double y);
     void plot();
 
@@ -25,12 +27,13 @@ private slots:
     //Custom signals
     void serialReceived();
 
-    // Graphical elements
+    //Layout elements
     void on_pb_connect_clicked();
     void on_pb_disconnect_clicked();
 
 private:
     Ui::MainWindow *ui;
+    QSerialPort *serial;
     comunicacaoSerial *comunicacaoSerial_;
     QVector<double> qv_x{0}, qv_y{0};
  //   comunicacaoSerial *comunicacaoSerial;

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>1114</width>
+    <height>599</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,8 +17,8 @@
    <widget class="QLabel" name="label">
     <property name="geometry">
      <rect>
-      <x>260</x>
-      <y>100</y>
+      <x>370</x>
+      <y>40</y>
       <width>67</width>
       <height>17</height>
      </rect>
@@ -27,33 +27,115 @@
      <string>TextLabel</string>
     </property>
    </widget>
-   <widget class="QComboBox" name="comboBox">
-    <property name="geometry">
-     <rect>
-      <x>540</x>
-      <y>90</y>
-      <width>86</width>
-      <height>25</height>
-     </rect>
-    </property>
-    <item>
-     <property name="text">
-      <string>value 1</string>
-     </property>
-    </item>
-    <item>
-     <property name="text">
-      <string>value 2</string>
-     </property>
-    </item>
-   </widget>
    <widget class="QCustomPlot" name="plot" native="true">
     <property name="geometry">
      <rect>
-      <x>40</x>
-      <y>190</y>
-      <width>721</width>
+      <x>10</x>
+      <y>260</y>
+      <width>1051</width>
       <height>301</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QGroupBox" name="groupBox">
+    <property name="geometry">
+     <rect>
+      <x>30</x>
+      <y>20</y>
+      <width>251</width>
+      <height>221</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>Serial Connection</string>
+    </property>
+    <widget class="QLabel" name="label_2">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>50</y>
+       <width>67</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Device:</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_3">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>90</y>
+       <width>81</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>BaudRate:</string>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="cb_serialDevices">
+     <property name="geometry">
+      <rect>
+       <x>100</x>
+       <y>40</y>
+       <width>131</width>
+       <height>31</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="cb_baudRate">
+     <property name="geometry">
+      <rect>
+       <x>100</x>
+       <y>80</y>
+       <width>131</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <item>
+      <property name="text">
+       <string>9600</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>19200</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>57600</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>115200</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QPushButton" name="pushButton">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>130</y>
+       <width>221</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Connect</string>
+     </property>
+    </widget>
+   </widget>
+   <widget class="QTextBrowser" name="tx_receivedData">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>40</y>
+      <width>61</width>
+      <height>201</height>
      </rect>
     </property>
    </widget>
@@ -63,10 +145,16 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>800</width>
+     <width>1114</width>
      <height>22</height>
     </rect>
    </property>
+   <widget class="QMenu" name="menuBiomedical_Serial_Monitor">
+    <property name="title">
+     <string>Biomedical Serial Monitor</string>
+    </property>
+   </widget>
+   <addaction name="menuBiomedical_Serial_Monitor"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
  </widget>

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -32,7 +32,7 @@
      <rect>
       <x>10</x>
       <y>260</y>
-      <width>1051</width>
+      <width>1091</width>
       <height>301</height>
      </rect>
     </property>
@@ -48,6 +48,9 @@
     </property>
     <property name="title">
      <string>Serial Connection</string>
+    </property>
+    <property name="flat">
+     <bool>false</bool>
     </property>
     <widget class="QLabel" name="label_2">
      <property name="geometry">

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -17,8 +17,8 @@
    <widget class="QLabel" name="label">
     <property name="geometry">
      <rect>
-      <x>370</x>
-      <y>40</y>
+      <x>1020</x>
+      <y>10</y>
       <width>67</width>
       <height>17</height>
      </rect>
@@ -42,7 +42,7 @@
      <rect>
       <x>30</x>
       <y>20</y>
-      <width>251</width>
+      <width>241</width>
       <height>221</height>
      </rect>
     </property>
@@ -96,6 +96,11 @@
      </property>
      <item>
       <property name="text">
+       <string>4800</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>9600</string>
       </property>
      </item>
@@ -115,7 +120,7 @@
       </property>
      </item>
     </widget>
-    <widget class="QPushButton" name="pushButton">
+    <widget class="QPushButton" name="pb_connect">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -128,15 +133,44 @@
       <string>Connect</string>
      </property>
     </widget>
+    <widget class="QPushButton" name="pb_disconnect">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>170</y>
+       <width>221</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Disconnect</string>
+     </property>
+    </widget>
    </widget>
    <widget class="QTextBrowser" name="tx_receivedData">
     <property name="geometry">
      <rect>
       <x>300</x>
-      <y>40</y>
-      <width>61</width>
-      <height>201</height>
+      <y>70</y>
+      <width>81</width>
+      <height>175</height>
      </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_4">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>40</y>
+      <width>81</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Last entries</string>
     </property>
    </widget>
   </widget>

--- a/source/simpleSerial.pro.user
+++ b/source/simpleSerial.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.12.3, 2020-07-02T09:06:26. -->
+<!-- Written by QtCreator 4.12.3, 2020-07-02T20:50:41. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -306,9 +306,8 @@
     </valuelist>
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">simpleSerial2</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/bossoares/Documents/Programação/Embarcados/simpleSerial_graph/simpleSerial.pro</value>
-    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/home/bossoares/Documents/Programação/Embarcados/simpleSerial_graph/simpleSerial.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/bossoares/Documents/Programação/Embarcados/serialMonitor/source/simpleSerial.pro</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/home/bossoares/Documents/Programação/Embarcados/serialMonitor/source/simpleSerial.pro</value>
     <value type="QString" key="RunConfiguration.Arguments"></value>
     <value type="bool" key="RunConfiguration.Arguments.multi">false</value>
     <value type="QString" key="RunConfiguration.OverrideDebuggerStartup"></value>


### PR DESCRIPTION
1 - Bug Fix: baudRate selection was not properly implemented. Due to a bug in the QSerial lib, the baudRate has to be selected after open the serial connection.
2 - Adjust layout of serial panel. Add a button to close the serial communication.
3 - Cleanup and organization of code.